### PR TITLE
covHisto_WG needs to be long[] to not overflow

### DIFF
--- a/ExCID_v2.0/bin/Java_code/WGS_Stats_v1.java
+++ b/ExCID_v2.0/bin/Java_code/WGS_Stats_v1.java
@@ -56,7 +56,7 @@ public class WGS_Stats_v1
 	static int hitTargetCount = 0;  //total targets with at least 1 read aligned to them
 	static int hitTarget_bufferonly_Count = 0; //total targets with no hits, except in buffer
 	static int[] covHisto = new int[1001]; //coverage histogram
-        static int[] covHisto_WG = new int[1001]; //coverage histogram for whole Genome
+        static long[] covHisto_WG = new long[1001]; //coverage histogram for whole Genome
 	static int nonTragetGoodHits = 0; //regions that have high coverage but are not in the target
 	static String VERSION = "WGSStatsV1.1 2015-03-25";
 	static Hashtable<String, SAMFileWriter> fht ; 


### PR DESCRIPTION
When computing a histogram across the whole genome, you'll need to use an array of longs to avoid integer overflow (so you don't get a histogram that says that -1414732325 bases were at zero coverage, for instance).

I notice that the basesWithOneHitorMore_WG variable and others like it were changed to longs instead of ints, so that's good. On the other hand, it might make more sense to just compute those from the histogram instead of keeping individual tallies as you go along.
